### PR TITLE
perf: fix SSH lag and add OSC 52 clipboard for headless sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3103,6 +3103,8 @@ version = "0.15.3"
 dependencies = [
  "anyhow",
  "arboard",
+ "base64",
+ "log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ chrono = { version = "0.4", features = ["serde"] }
 portable-pty = "0.8"
 vte = "0.13"
 # Additional shared dependencies
+base64 = "0.22"
 tempfile = "3.12"
 log = "0.4"
 libc = "0.2"
@@ -101,7 +102,7 @@ auto-req = "no"
 [dependencies]
 anyhow = "1.0"
 arboard = "3.4"
-base64 = "0.22"
+base64.workspace = true
 chrono = "0.4"
 clap = { version = "4", features = ["derive"] }
 crossterm = "0.28"

--- a/crates/app/src/app/mod.rs
+++ b/crates/app/src/app/mod.rs
@@ -13,6 +13,7 @@ use std::time::Duration;
 
 use termide_app_core::{LayoutController, PanelProvider};
 use termide_app_event::DefaultHotkeyProcessor;
+use crossterm::event::MouseEventKind;
 use termide_core::event::{Event, EventHandler};
 use termide_layout::{LayoutManager, PanelGroup};
 
@@ -370,12 +371,19 @@ impl App {
                     self.state.needs_redraw = true;
                 }
                 Event::Mouse(mouse) => {
-                    self.state.last_activity = std::time::Instant::now();
-                    self.event_handler.set_tick_rate(Duration::from_millis(
-                        termide_config::constants::EVENT_HANDLER_INTERVAL_MS,
-                    ));
+                    // Mouse movement (hover) should not reset idle timer or force redraws.
+                    // Only actionable events (clicks, drags) wake from idle.
+                    let is_move = matches!(mouse.kind, MouseEventKind::Moved);
+                    if !is_move {
+                        self.state.last_activity = std::time::Instant::now();
+                        self.event_handler.set_tick_rate(Duration::from_millis(
+                            termide_config::constants::EVENT_HANDLER_INTERVAL_MS,
+                        ));
+                    }
                     self.handle_mouse_event(mouse)?;
-                    self.state.needs_redraw = true;
+                    if !is_move {
+                        self.state.needs_redraw = true;
+                    }
                 }
                 Event::Resize(width, height) => {
                     // Update terminal dimensions in state

--- a/crates/clipboard/Cargo.toml
+++ b/crates/clipboard/Cargo.toml
@@ -10,3 +10,5 @@ description = "Clipboard operations for termide"
 [dependencies]
 arboard.workspace = true
 anyhow.workspace = true
+base64.workspace = true
+log.workspace = true

--- a/crates/clipboard/src/lib.rs
+++ b/crates/clipboard/src/lib.rs
@@ -1,9 +1,11 @@
 //! Clipboard operations for termide.
 //!
-//! Provides cross-platform clipboard access using arboard.
-//! On Linux, supports both CLIPBOARD and PRIMARY selections.
+//! Provides cross-platform clipboard access using arboard with OSC 52
+//! fallback for remote/SSH sessions where no display server is available.
 
 use arboard::Clipboard;
+use base64::{engine::general_purpose::STANDARD, Engine};
+use std::io::Write;
 use std::sync::{Mutex, OnceLock};
 
 #[cfg(target_os = "linux")]
@@ -23,10 +25,30 @@ fn get_clipboard() -> Result<&'static Mutex<Clipboard>, String> {
         .ok_or_else(|| "Clipboard unavailable (no display server?)".to_string())
 }
 
+/// Copy text to the terminal's clipboard via OSC 52 escape sequence.
+///
+/// This works over SSH when the terminal emulator supports OSC 52
+/// (Windows Terminal, iTerm2, kitty, foot, alacritty, etc.).
+fn osc52_copy(text: &str) -> Result<(), String> {
+    let encoded = STANDARD.encode(text.as_bytes());
+    // OSC 52 ; c ; <base64> ST
+    // 'c' = clipboard selection
+    let sequence = format!("\x1b]52;c;{}\x07", encoded);
+    let mut stdout = std::io::stdout().lock();
+    stdout
+        .write_all(sequence.as_bytes())
+        .map_err(|e| format!("Failed to write OSC 52: {}", e))?;
+    stdout
+        .flush()
+        .map_err(|e| format!("Failed to flush OSC 52: {}", e))?;
+    Ok(())
+}
+
 /// Copy text to system clipboard.
 ///
-/// Uses arboard for cross-platform clipboard access.
-/// On Linux, copies to BOTH CLIPBOARD and PRIMARY selections.
+/// Uses arboard for local clipboard access. Falls back to OSC 52
+/// escape sequence when no display server is available (SSH sessions).
+/// On Linux with a display server, copies to BOTH CLIPBOARD and PRIMARY selections.
 ///
 /// Returns Ok(()) on success, or Err with detailed error message.
 pub fn copy(text: &str) -> Result<(), String> {
@@ -34,6 +56,20 @@ pub fn copy(text: &str) -> Result<(), String> {
         return Err("Cannot copy empty text".to_string());
     }
 
+    // Try arboard first (works with display server)
+    let arboard_result = copy_arboard(text);
+
+    if arboard_result.is_ok() {
+        return Ok(());
+    }
+
+    // Fall back to OSC 52 for SSH/headless sessions
+    log::debug!("arboard clipboard unavailable, falling back to OSC 52");
+    osc52_copy(text)
+}
+
+/// Copy text using arboard (requires display server).
+fn copy_arboard(text: &str) -> Result<(), String> {
     #[cfg(target_os = "linux")]
     {
         let mut clipboard = get_clipboard()?
@@ -76,6 +112,10 @@ pub fn copy(text: &str) -> Result<(), String> {
 ///
 /// On Linux, tries CLIPBOARD selection first, then falls back to PRIMARY.
 /// Returns None if clipboard is empty or inaccessible.
+///
+/// Note: OSC 52 paste (reading from terminal) is not supported because it requires
+/// async terminal response handling. Paste in SSH sessions relies on the terminal
+/// emulator's bracketed paste (Ctrl+V in the terminal sends the text directly).
 pub fn paste() -> Option<String> {
     let mut clipboard = get_clipboard().ok()?.lock().ok()?;
 


### PR DESCRIPTION
## Summary
- **Mouse hover no longer prevents idle mode**: `MouseEventKind::Moved` was resetting the idle timer, boosting tick rate to 42ms (24 FPS), and forcing redraws on every event. This kept the app rendering at full speed whenever the cursor was over the window, causing major lag over SSH. Now only clicks and drags wake from idle.
- **OSC 52 clipboard fallback**: `arboard` requires X11/Wayland which is unavailable in SSH sessions. When arboard fails, clipboard copy now falls back to OSC 52 escape sequences, supported by Windows Terminal, iTerm2, kitty, alacritty, and most modern terminals.

## Test plan
- [x] Tested over SSH (Windows Terminal → Ubuntu Linux) — lag eliminated, clipboard copy/paste works
- [x] Release build compiles cleanly
- [ ] Verify no regression on local (non-SSH) usage