### PR TITLE
perf(ssh): ghost divider drag + fix source file open behavior

### DIFF
--- a/crates/app/src/app/mod.rs
+++ b/crates/app/src/app/mod.rs
@@ -447,8 +447,10 @@ impl App {
                         .map(|t| t.elapsed() < Duration::from_millis(100))
                         .unwrap_or(false);
 
-                    // Skip heavy operations during active scrolling
-                    if !is_scrolling {
+                    let is_dragging = self.state.ui.drag.is_dragging();
+
+                    // Skip heavy operations during active scrolling or divider drag
+                    if !is_scrolling && !is_dragging {
                         // Single combined loop: terminal output + panel tick + FM spinner
                         let mut all_panel_events = Vec::new();
                         for (panel, is_expanded) in self

--- a/crates/app/src/app/mouse_handler.rs
+++ b/crates/app/src/app/mouse_handler.rs
@@ -1091,39 +1091,46 @@ impl App {
         Ok(false)
     }
 
-    /// Handle divider drag (update widths)
+    /// Handle divider drag — track cursor position and draw ghost line.
+    /// Only the ghost divider line is rendered (lightweight), while actual
+    /// panel resize is deferred to mouse release.
     fn handle_divider_drag(&mut self, current_x: u16) -> Result<()> {
-        let drag = &self.state.ui.drag;
-        let Some(divider_idx) = drag.active_divider else {
+        if self.state.ui.drag.last_applied_x == Some(current_x) {
             return Ok(());
-        };
-
-        let delta = current_x as i32 - drag.start_x as i32;
-        let (start_left, start_right) = drag.start_widths;
-
-        // Calculate new widths with min_panel_width constraint
-        let min_width = self.state.config.general.min_panel_width;
-        let total_width = start_left + start_right;
-
-        let new_left = (start_left as i32 + delta)
-            .max(min_width as i32)
-            .min((total_width - min_width) as i32) as u16;
-        let new_right = total_width - new_left;
-
-        // Apply new widths
-        self.layout_manager
-            .resize_groups(divider_idx, new_left, new_right);
+        }
+        self.state.ui.drag.last_applied_x = Some(current_x);
+        // Trigger redraw for the ghost line — this is lightweight because
+        // only ~2 columns change (ratatui diff rendering sends minimal data).
         self.state.needs_redraw = true;
-
         Ok(())
     }
 
-    /// Handle divider drag end (save session)
+    /// Handle divider drag end — apply final widths and redraw once.
     fn handle_divider_drag_end(&mut self) -> Result<()> {
+        // Apply the accumulated drag position as a single resize
+        if let (Some(divider_idx), Some(final_x)) = (
+            self.state.ui.drag.active_divider,
+            self.state.ui.drag.last_applied_x,
+        ) {
+            let delta = final_x as i32 - self.state.ui.drag.start_x as i32;
+            let (start_left, start_right) = self.state.ui.drag.start_widths;
+
+            let min_width = self.state.config.general.min_panel_width;
+            let total_width = start_left + start_right;
+
+            let new_left = (start_left as i32 + delta)
+                .max(min_width as i32)
+                .min((total_width - min_width) as i32) as u16;
+            let new_right = total_width - new_left;
+
+            self.layout_manager
+                .resize_groups(divider_idx, new_left, new_right);
+        }
+
         self.state.ui.drag.end();
         self.state.needs_redraw = true;
 
-        // Save session with new widths (debounce: only on mouse up)
+        // Save session with new widths
         self.auto_save_session();
 
         Ok(())

--- a/crates/config/src/constants.rs
+++ b/crates/config/src/constants.rs
@@ -87,5 +87,9 @@ pub const IDLE_TICK_MS: u64 = 200;
 /// Duration of inactivity before switching to idle tick rate (in milliseconds).
 pub const IDLE_THRESHOLD_MS: u64 = 500;
 
+/// Tick rate during divider drag in milliseconds (83ms = ~12 FPS).
+/// Lower frame rate reduces data sent over SSH while dragging panel dividers.
+pub const DRAG_TICK_MS: u64 = 83;
+
 /// Double-click detection interval in milliseconds.
 pub const DOUBLE_CLICK_INTERVAL_MS: u128 = 500;

--- a/crates/core/src/event.rs
+++ b/crates/core/src/event.rs
@@ -83,6 +83,11 @@ impl EventHandler {
                 {
                     self.coalesce_scroll_events(mouse)
                 }
+                CrosstermEvent::Mouse(mouse)
+                    if matches!(mouse.kind, MouseEventKind::Drag(_)) =>
+                {
+                    self.coalesce_drag_events(mouse)
+                }
                 CrosstermEvent::Mouse(mouse) => Ok(Event::Mouse(mouse)),
                 CrosstermEvent::Resize(width, height) => Ok(Event::Resize(width, height)),
                 CrosstermEvent::FocusLost => Ok(Event::FocusLost),
@@ -142,6 +147,32 @@ impl EventHandler {
             event: first,
             delta,
         })
+    }
+
+    /// Coalesce multiple drag events into a single event with the latest position.
+    /// This prevents processing dozens of intermediate drag positions when the
+    /// user moves the mouse quickly, significantly reducing lag over SSH.
+    fn coalesce_drag_events(&self, first: MouseEvent) -> Result<Event> {
+        let mut latest = first;
+
+        // Drain queue with zero timeout to collect pending drag events
+        while event::poll(Duration::ZERO)? {
+            let raw = event::read()?;
+            match &raw {
+                CrosstermEvent::Mouse(m) if matches!(m.kind, MouseEventKind::Drag(_)) => {
+                    latest = *m;
+                }
+                _ => {
+                    // Queue non-drag event for later processing
+                    if let Some(ev) = self.convert_crossterm_event(raw) {
+                        self.pending_events.borrow_mut().push_back(ev);
+                    }
+                    break;
+                }
+            }
+        }
+
+        Ok(Event::Mouse(latest))
     }
 
     /// Convert crossterm event to our Event type.

--- a/crates/panel-file-manager/src/lib.rs
+++ b/crates/panel-file-manager/src/lib.rs
@@ -142,17 +142,22 @@ fn determine_file_open_event(
                 return Some(PanelEvent::OpenExternal(file_path.to_path_buf()));
             }
 
-            // 3. Executable → run in terminal
+            // 3. Source/text files with known extensions → editor (even if executable)
+            if is_source_file(&entry.name) {
+                return Some(PanelEvent::OpenFile(file_path.to_path_buf()));
+            }
+
+            // 4. Executable binary → run in terminal
             if entry.is_executable {
                 return Some(PanelEvent::ExecuteFile(file_path.to_path_buf()));
             }
 
-            // 4. Binary files → xdg-open
+            // 5. Binary files → xdg-open
             if is_binary_file(file_path) {
                 return Some(PanelEvent::OpenExternal(file_path.to_path_buf()));
             }
 
-            // 5. Text files → editor (editable)
+            // 6. Text files → editor (editable)
             Some(PanelEvent::OpenFile(file_path.to_path_buf()))
         }
     }
@@ -2521,6 +2526,43 @@ fn is_video(filename: &str) -> bool {
         get_extension(filename).as_str(),
         "mp4" | "mkv" | "avi" | "mov" | "webm" | "flv" | "wmv" | "m4v"
     )
+}
+
+/// Check if file has a known source/text extension that should open in the editor
+/// even if the executable bit is set (e.g. `.sh`, `.py` scripts).
+fn is_source_file(filename: &str) -> bool {
+    matches!(
+        get_extension(filename).as_str(),
+        // Shell scripts
+        "sh" | "bash" | "zsh" | "fish" | "ksh" | "csh" |
+        // Scripting languages
+        "py" | "rb" | "pl" | "pm" | "lua" | "tcl" | "awk" |
+        // Compiled languages (source files)
+        "rs" | "go" | "c" | "h" | "cpp" | "cc" | "cxx" | "hpp" |
+        "java" | "kt" | "scala" | "cs" | "hs" | "lhs" |
+        // Web / JS / TS
+        "js" | "mjs" | "cjs" | "ts" | "tsx" | "jsx" |
+        "html" | "htm" | "css" | "scss" | "sass" | "less" |
+        // Config / data
+        "json" | "yaml" | "yml" | "toml" | "xml" | "ini" | "cfg" |
+        "conf" | "env" | "properties" |
+        // Markup / docs
+        "md" | "rst" | "txt" | "tex" | "adoc" |
+        // Nix / PHP / other
+        "nix" | "php" | "r" | "jl" | "ex" | "exs" | "erl" |
+        // Build / CI
+        "cmake" | "make" | "mk" | "gradle" | "sbt" |
+        // SQL / DB
+        "sql" |
+        // Docker / misc
+        "dockerfile"
+    ) || filename.eq_ignore_ascii_case("Makefile")
+      || filename.eq_ignore_ascii_case("Dockerfile")
+      || filename.eq_ignore_ascii_case("Rakefile")
+      || filename.eq_ignore_ascii_case("Gemfile")
+      || filename.eq_ignore_ascii_case("Vagrantfile")
+      || filename.eq_ignore_ascii_case(".gitignore")
+      || filename.eq_ignore_ascii_case(".env")
 }
 
 #[cfg(test)]

--- a/crates/state/src/ui.rs
+++ b/crates/state/src/ui.rs
@@ -70,6 +70,8 @@ pub struct DragState {
     pub start_x: u16,
     /// Initial widths of left and right groups
     pub start_widths: (u16, u16),
+    /// Last column applied (skip redraw if unchanged)
+    pub last_applied_x: Option<u16>,
 }
 
 impl DragState {
@@ -83,6 +85,7 @@ impl DragState {
     /// End dragging
     pub fn end(&mut self) {
         self.active_divider = None;
+        self.last_applied_x = None;
     }
 
     /// Check if currently dragging

--- a/crates/ui-render/src/panel_rendering.rs
+++ b/crates/ui-render/src/panel_rendering.rs
@@ -244,6 +244,7 @@ pub fn render_dividers(
     buf: &mut Buffer,
     divider_positions: &[(usize, u16)], // (group_idx, x_position)
     active_divider: Option<usize>,
+    ghost_x: Option<u16>,
     terminal_height: u16,
     theme: &Theme,
 ) {
@@ -257,12 +258,24 @@ pub fn render_dividers(
     let end_y = terminal_height.saturating_sub(1);
     let style = Style::default().fg(theme.accented_fg);
 
-    // Find and draw only the active divider
+    // If a ghost position is provided, draw the ghost divider there instead.
+    // This allows visual feedback during drag without resizing panels.
+    if let Some(gx) = ghost_x {
+        let positions = [gx.saturating_sub(1), gx];
+        for y in start_y..end_y {
+            for &pos in &positions {
+                if let Some(cell) = buf.cell_mut((pos, y)) {
+                    cell.set_symbol("║");
+                    cell.set_style(style);
+                }
+            }
+        }
+        return;
+    }
+
+    // Find and draw only the active divider at its current position
     for &(group_idx, x) in divider_positions {
         if group_idx == active_idx {
-            // Draw at both border positions:
-            // x-1 = right border of left panel
-            // x = left border of right panel
             let positions = [x.saturating_sub(1), x];
             for y in start_y..end_y {
                 for &pos in &positions {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -310,12 +310,13 @@ fn render_main_area_with_accordion(
             render_panel_group(frame, group_area, state, group, group_idx, is_active_group);
         }
 
-        // Render dividers between groups
+        // Render dividers between groups (ghost line during drag)
         let divider_positions = layout_manager.get_divider_positions();
         render_dividers(
             frame.buffer_mut(),
             &divider_positions,
             state.ui.drag.active_divider,
+            state.ui.drag.last_applied_x,
             state.terminal.height,
             state.theme,
         );


### PR DESCRIPTION
## Summary

Fixes for SSH/remote session usage:

- **Ghost divider line during drag (SSH optimization)**: Instead of resizing panels on every drag pixel (which sends a full-screen redraw over SSH), a lightweight ghost `║` line follows the cursor (~100 cells vs ~10,000 cells per frame). Actual resize happens on mouse release.
- **Drag event coalescing**: Multiple queued drag events are collapsed into the latest position, matching the existing scroll coalescing pattern. Reduces redundant processing over SSH.
- **Skip heavy tick operations during drag**: Git status, file watchers, VFS polling are skipped while dragging (same as during scrolling).
- **Fix source file opening**: Files with known source extensions (.sh, .py, .rb, etc.) now open in the editor even when the executable bit is set, instead of being executed in a terminal. Users can still run files via Shift+Enter.

## Test plan
- [x] Tested divider drag over SSH (Windows Terminal → Ubuntu) — ghost line is smooth, panels snap on release
- [x] Tested .sh and .py files open in editor instead of running
- [x] Release build compiles cleanly
- [ ] Verify no regression on local (non-SSH) divider drag