### PR TITLE
feat: network throughput monitor + cfg(unix) cleanup

### DIFF
--- a/crates/app/src/app/background_ops.rs
+++ b/crates/app/src/app/background_ops.rs
@@ -380,7 +380,7 @@ impl App {
         }
     }
 
-    /// Update system resource monitoring (CPU, RAM)
+    /// Update system resource monitoring (CPU, RAM, network)
     /// Respects the configured update interval.
     /// Only triggers redraw if display values actually changed.
     pub(super) fn update_system_resources(&mut self) {
@@ -390,12 +390,18 @@ impl App {
 
         if elapsed >= interval {
             let old_stats = self.state.system_monitor.stats();
+            let old_net_down = self.state.system_monitor.net_download_rate();
+            let old_net_up = self.state.system_monitor.net_upload_rate();
             self.state.system_monitor.update();
             self.state.last_resource_update = std::time::Instant::now();
             let new_stats = self.state.system_monitor.stats();
-            // Only redraw if display values actually changed (rounded CPU% or MB of memory)
+            let new_net_down = self.state.system_monitor.net_download_rate();
+            let new_net_up = self.state.system_monitor.net_upload_rate();
+            // Only redraw if display values actually changed
             if old_stats.cpu_usage.round() as u8 != new_stats.cpu_usage.round() as u8
                 || old_stats.memory_used / (1024 * 1024) != new_stats.memory_used / (1024 * 1024)
+                || old_net_down / 1024 != new_net_down / 1024
+                || old_net_up / 1024 != new_net_up / 1024
             {
                 self.state.needs_redraw = true;
             }

--- a/crates/app/src/app/modal/input_handler.rs
+++ b/crates/app/src/app/modal/input_handler.rs
@@ -96,12 +96,17 @@ impl App {
     ) -> Result<()> {
         // Store info needed for LSP notification (before mutable borrow)
         let mut lsp_info: Option<(String, PathBuf)> = None;
+        #[cfg(unix)]
         let mut saved_path: Option<PathBuf> = None;
+        #[cfg(unix)]
         let mut make_executable = false;
 
         if let Some(result) = value.downcast_ref::<SaveAsResult>() {
             let t = i18n::t();
-            make_executable = result.executable;
+            #[cfg(unix)]
+            {
+                make_executable = result.executable;
+            }
 
             // Get active Editor panel and save file
             if let Some(panel) = self.layout_manager.active_panel_mut() {
@@ -119,7 +124,10 @@ impl App {
                         Ok(_) => {
                             log::info!("File saved as: {}", display_path);
                             self.state.set_info(t.status_file_saved(&display_path));
-                            saved_path = Some(file_path.clone());
+                            #[cfg(unix)]
+                            {
+                                saved_path = Some(file_path.clone());
+                            }
 
                             // Collect LSP info for didSave notification
                             if let Some(lang) = editor.lsp_language() {
@@ -135,24 +143,21 @@ impl App {
             }
         }
 
-        // Set executable permission if requested
+        // Set executable permission if requested (Unix only — Windows has no executable bit)
+        #[cfg(unix)]
         if make_executable {
-            if let Some(ref _path) = saved_path {
-                #[cfg(unix)]
-                {
-                    let path = _path;
-                    use std::os::unix::fs::PermissionsExt;
-                    if let Ok(metadata) = std::fs::metadata(path) {
-                        let mut perms = metadata.permissions();
-                        let mode = perms.mode();
-                        // Add execute bits for user, group, and others (where read is set)
-                        let new_mode = mode | ((mode & 0o444) >> 2);
-                        perms.set_mode(new_mode);
-                        if let Err(e) = std::fs::set_permissions(path, perms) {
-                            log::warn!("Failed to set executable permission: {}", e);
-                        } else {
-                            log::info!("Set executable permission on: {}", path.display());
-                        }
+            if let Some(ref path) = saved_path {
+                use std::os::unix::fs::PermissionsExt;
+                if let Ok(metadata) = std::fs::metadata(path) {
+                    let mut perms = metadata.permissions();
+                    let mode = perms.mode();
+                    // Add execute bits for user, group, and others (where read is set)
+                    let new_mode = mode | ((mode & 0o444) >> 2);
+                    perms.set_mode(new_mode);
+                    if let Err(e) = std::fs::set_permissions(path, perms) {
+                        log::warn!("Failed to set executable permission: {}", e);
+                    } else {
+                        log::info!("Set executable permission on: {}", path.display());
                     }
                 }
             }

--- a/crates/app/src/app/mouse_handler.rs
+++ b/crates/app/src/app/mouse_handler.rs
@@ -476,6 +476,8 @@ impl App {
             ram_percent: self.state.system_monitor.ram_usage_percent(),
             ram_value,
             ram_unit,
+            net_down_rate: self.state.system_monitor.net_download_rate(),
+            net_up_rate: self.state.system_monitor.net_upload_rate(),
             toggle_menu_key,
         };
         get_resource_indicator_ranges(self.state.terminal.width, &params)

--- a/crates/system-monitor/src/lib.rs
+++ b/crates/system-monitor/src/lib.rs
@@ -1,11 +1,13 @@
 //! System resource monitoring for termide.
 //!
-//! Provides CPU and memory usage information.
+//! Provides CPU, memory, and network usage information.
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
+use std::time::Instant;
 use sysinfo::{
-    CpuRefreshKind, MemoryRefreshKind, ProcessRefreshKind, RefreshKind, System, UpdateKind,
+    CpuRefreshKind, MemoryRefreshKind, Networks, ProcessRefreshKind, RefreshKind, System,
+    UpdateKind,
 };
 
 /// System resource statistics.
@@ -37,10 +39,27 @@ pub enum RamUnit {
     Megabytes,
 }
 
+/// Network throughput state.
+struct NetworkState {
+    networks: Networks,
+    download_rate: u64,
+    upload_rate: u64,
+    last_refresh: Instant,
+}
+
 /// System monitor for tracking resource usage.
-#[derive(Debug)]
 pub struct SystemMonitor {
     system: Arc<Mutex<System>>,
+    net_state: Mutex<NetworkState>,
+}
+
+// Manual Debug impl because Networks doesn't implement Debug
+impl std::fmt::Debug for SystemMonitor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SystemMonitor")
+            .field("system", &self.system)
+            .finish_non_exhaustive()
+    }
 }
 
 impl Default for SystemMonitor {
@@ -62,8 +81,16 @@ impl SystemMonitor {
         let mut system = System::new_with_specifics(refresh_kind);
         system.refresh_specifics(refresh_kind);
 
+        let networks = Networks::new_with_refreshed_list();
+
         Self {
             system: Arc::new(Mutex::new(system)),
+            net_state: Mutex::new(NetworkState {
+                networks,
+                download_rate: 0,
+                upload_rate: 0,
+                last_refresh: Instant::now(),
+            }),
         }
     }
 
@@ -83,6 +110,31 @@ impl SystemMonitor {
     pub fn refresh(&self) {
         if let Ok(mut sys) = self.system.lock() {
             sys.refresh_specifics(Self::refresh_kind());
+        }
+        self.refresh_networks();
+    }
+
+    /// Refresh network statistics and compute throughput rates.
+    fn refresh_networks(&self) {
+        if let Ok(mut state) = self.net_state.lock() {
+            let elapsed = state.last_refresh.elapsed();
+            let elapsed_secs = elapsed.as_secs_f64();
+
+            state.networks.refresh();
+
+            let mut total_rx: u64 = 0;
+            let mut total_tx: u64 = 0;
+            for (_name, data) in &state.networks {
+                total_rx += data.received();
+                total_tx += data.transmitted();
+            }
+
+            if elapsed_secs > 0.0 {
+                state.download_rate = (total_rx as f64 / elapsed_secs) as u64;
+                state.upload_rate = (total_tx as f64 / elapsed_secs) as u64;
+            }
+
+            state.last_refresh = Instant::now();
         }
     }
 
@@ -152,6 +204,22 @@ impl SystemMonitor {
             let (used_mb, total_mb) = self.ram_info_mb();
             (format!("{}/{}", used_mb, total_mb), RamUnit::Megabytes)
         }
+    }
+
+    /// Get network download rate in bytes per second.
+    pub fn net_download_rate(&self) -> u64 {
+        self.net_state
+            .lock()
+            .map(|s| s.download_rate)
+            .unwrap_or(0)
+    }
+
+    /// Get network upload rate in bytes per second.
+    pub fn net_upload_rate(&self) -> u64 {
+        self.net_state
+            .lock()
+            .map(|s| s.upload_rate)
+            .unwrap_or(0)
     }
 
     /// Get top N processes by CPU usage, grouped by binary name.
@@ -287,6 +355,25 @@ impl DiskSpaceInfo {
         self.device
             .as_ref()
             .map(|d| d.strip_prefix("/dev/").unwrap_or(d).to_uppercase())
+    }
+}
+
+/// Format network speed as compact human-readable string.
+///
+/// Returns strings like "0B", "4kB", "1.2MB", "2.5GB".
+pub fn format_net_speed(bytes_per_sec: u64) -> String {
+    const KB: u64 = 1024;
+    const MB: u64 = KB * 1024;
+    const GB: u64 = MB * 1024;
+
+    if bytes_per_sec >= GB {
+        format!("{:.1}GB", bytes_per_sec as f64 / GB as f64)
+    } else if bytes_per_sec >= MB {
+        format!("{:.1}MB", bytes_per_sec as f64 / MB as f64)
+    } else if bytes_per_sec >= KB {
+        format!("{}kB", bytes_per_sec / KB)
+    } else {
+        format!("{}B", bytes_per_sec)
     }
 }
 

--- a/crates/ui-render/src/menu.rs
+++ b/crates/ui-render/src/menu.rs
@@ -13,7 +13,7 @@ use ratatui::{
 use unicode_width::UnicodeWidthStr;
 
 use termide_i18n as i18n;
-use termide_system_monitor::RamUnit;
+use termide_system_monitor::{format_net_speed, RamUnit};
 use termide_theme::Theme;
 
 /// Parameters for rendering the menu bar.
@@ -25,6 +25,10 @@ pub struct MenuRenderParams<'a> {
     pub ram_percent: u8,
     pub ram_value: String,
     pub ram_unit: RamUnit,
+    /// Network download rate in bytes per second
+    pub net_down_rate: u64,
+    /// Network upload rate in bytes per second
+    pub net_up_rate: u64,
     /// Toggle menu keybinding display string (e.g., "Alt+M")
     pub toggle_menu_key: &'a str,
 }
@@ -146,6 +150,8 @@ pub fn get_resource_indicator_ranges(
         format!("{} {}", params.toggle_menu_key, t.menu_open_hint_label()).into()
     };
 
+    let net_down_text = format!("↓{} ", format_net_speed(params.net_down_rate));
+    let net_up_text = format!("↑{} ", format_net_speed(params.net_up_rate));
     let cpu_text = format!("CPU {}% ", params.cpu_usage);
     let ram_text = format!("RAM {}{} ", params.ram_value, ram_unit_str);
     let current_time = chrono::Local::now().format("%H:%M").to_string();
@@ -154,13 +160,22 @@ pub fn get_resource_indicator_ranges(
     let hint_with_padding = format!(" {} ", hint);
 
     // Calculate positions from the right side
-    // Layout order: ... [padding] [hint] [cpu] [ram] [clock]
+    // Layout order: ... [padding] [hint] [net_down] [net_up] [cpu] [ram] [clock]
     let remaining = (area_width as usize).saturating_sub(
-        used_width + hint.width() + 2 + cpu_text.width() + ram_text.width() + clock_text.width(),
+        used_width
+            + hint.width()
+            + 2
+            + net_down_text.width()
+            + net_up_text.width()
+            + cpu_text.width()
+            + ram_text.width()
+            + clock_text.width(),
     );
 
     let mut x = used_width + remaining;
     x += hint_with_padding.width(); // skip hint
+    x += net_down_text.width(); // skip net down
+    x += net_up_text.width(); // skip net up
 
     let cpu_start = x as u16;
     let cpu_end = cpu_start + cpu_text.width() as u16;
@@ -206,6 +221,10 @@ pub fn render_menu(frame: &mut Frame, area: Rect, params: &MenuRenderParams) {
         RamUnit::Megabytes => t.size_megabytes(),
     };
 
+    // Network indicators
+    let net_down_text = format!("↓{} ", format_net_speed(params.net_down_rate));
+    let net_up_text = format!("↑{} ", format_net_speed(params.net_up_rate));
+
     // CPU indicator
     let cpu_text = format!("CPU {}% ", params.cpu_usage);
     let cpu_color = resource_color(params.cpu_usage, params.theme);
@@ -221,7 +240,14 @@ pub fn render_menu(frame: &mut Frame, area: Rect, params: &MenuRenderParams) {
     // Calculate spacing
     let used_width: usize = spans.iter().map(|s| s.width()).sum();
     let remaining = (area.width as usize).saturating_sub(
-        used_width + hint.width() + 2 + cpu_text.width() + ram_text.width() + clock_text.width(),
+        used_width
+            + hint.width()
+            + 2
+            + net_down_text.width()
+            + net_up_text.width()
+            + cpu_text.width()
+            + ram_text.width()
+            + clock_text.width(),
     );
 
     if remaining > 0 {
@@ -238,6 +264,12 @@ pub fn render_menu(frame: &mut Frame, area: Rect, params: &MenuRenderParams) {
 
     // Add hint
     spans.push(Span::styled(format!(" {} ", hint), hint_style));
+
+    // Add network indicators
+    let net_down_style = Style::default().fg(params.theme.success);
+    let net_up_style = Style::default().fg(Color::Cyan);
+    spans.push(Span::styled(net_down_text, net_down_style));
+    spans.push(Span::styled(net_up_text, net_up_style));
 
     // Add CPU indicator
     spans.push(Span::styled(cpu_text, cpu_style));

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -252,6 +252,8 @@ pub fn render_layout_with_accordion(
         ram_percent: state.system_monitor.ram_usage_percent(),
         ram_value,
         ram_unit,
+        net_down_rate: state.system_monitor.net_download_rate(),
+        net_up_rate: state.system_monitor.net_upload_rate(),
         toggle_menu_key,
     };
     render_menu(frame, main_chunks[0], &menu_params);


### PR DESCRIPTION
## Summary

- **Network throughput in header bar**: Real-time ↓download/↑upload speeds displayed between the Alt+M hint and CPU indicator, using `sysinfo::Networks` for cross-platform support (no `#[cfg]` gates needed)
- **`#[cfg(unix)]` cleanup**: Addresses [review feedback from PR #7](https://github.com/termide/termide/pull/7#pullrequestreview-3950515080) — replaces the `let path = _path;` workaround in `input_handler.rs` with proper platform-conditional compilation. Variables `saved_path` and `make_executable` now only exist on Unix, eliminating warnings without `#[allow]` attributes.

### Header layout
```
[Sessions Windows Scripts Bookmarks Options]  ...  [Alt+M Menu] [↓4kB] [↑2kB] [CPU 45%] [RAM 8/16GB] [14:30]
```

### Files changed
| File | Change |
|------|--------|
| `crates/system-monitor/src/lib.rs` | Add `Networks` tracking, download/upload rate calculation, `format_net_speed()` |
| `crates/ui-render/src/menu.rs` | Add network spans (green ↓, cyan ↑) + update width calculations |
| `src/ui.rs` | Pass network rates through `MenuRenderParams` |
| `crates/app/src/app/background_ops.rs` | Include network rate changes in redraw check |
| `crates/app/src/app/mouse_handler.rs` | Pass network rates to `MenuRenderParams` |
| `crates/app/src/app/modal/input_handler.rs` | Gate unix-only variables behind `#[cfg(unix)]` |

## Test plan
- [x] Compiles with zero warnings on Windows
- [x] All 18 system-monitor unit tests pass
- [x] Release build succeeds
- [ ] Verify network indicators update in real-time on Linux
- [ ] Verify header layout doesn't overflow on narrow terminals