### PR TITLE
feat: add "terminal" theme

### DIFF
--- a/crates/theme/src/lib.rs
+++ b/crates/theme/src/lib.rs
@@ -80,6 +80,7 @@ const THEME_NORTON_COMMANDER_TOML: &str = include_str!("../themes/norton-command
 const THEME_ONEDARK_TOML: &str = include_str!("../themes/onedark.toml");
 const THEME_PIP_BOY_TOML: &str = include_str!("../themes/pip-boy.toml");
 const THEME_SOLARIZED_DARK_TOML: &str = include_str!("../themes/solarized-dark.toml");
+const THEME_TERMINAL_TOML: &str = include_str!("../themes/terminal.toml");
 const THEME_TERMINATOR_TOML: &str = include_str!("../themes/terminator.toml");
 const THEME_SOLARIZED_LIGHT_TOML: &str = include_str!("../themes/solarized-light.toml");
 const THEME_VOLKOV_COMMANDER_TOML: &str = include_str!("../themes/volkov-commander.toml");
@@ -106,6 +107,7 @@ static THEME_NORTON_COMMANDER: OnceLock<Theme> = OnceLock::new();
 static THEME_ONEDARK: OnceLock<Theme> = OnceLock::new();
 static THEME_PIP_BOY: OnceLock<Theme> = OnceLock::new();
 static THEME_SOLARIZED_DARK: OnceLock<Theme> = OnceLock::new();
+static THEME_TERMINAL: OnceLock<Theme> = OnceLock::new();
 static THEME_TERMINATOR: OnceLock<Theme> = OnceLock::new();
 static THEME_SOLARIZED_LIGHT: OnceLock<Theme> = OnceLock::new();
 static THEME_VOLKOV_COMMANDER: OnceLock<Theme> = OnceLock::new();
@@ -219,6 +221,11 @@ static BUILTIN_THEMES: &[BuiltinThemeEntry] = &[
         name: "solarized-light",
         content: THEME_SOLARIZED_LIGHT_TOML,
         storage: &THEME_SOLARIZED_LIGHT,
+    },
+    BuiltinThemeEntry {
+        name: "terminal",
+        content: THEME_TERMINAL_TOML,
+        storage: &THEME_TERMINAL,
     },
     BuiltinThemeEntry {
         name: "terminator",

--- a/crates/theme/themes/terminal.toml
+++ b/crates/theme/themes/terminal.toml
@@ -1,0 +1,25 @@
+# Classic terminal theme for TermIDE
+# Pure black background with bright text, like a traditional terminal
+name = "terminal"
+is_light = false
+
+[colors]
+# Base - pure black background, bright white text
+bg = { rgb = [0, 0, 0] }
+fg = { rgb = [204, 204, 204] }
+
+# Accented - dark gray panel headers with white text
+accented_bg = { rgb = [30, 30, 30] }
+accented_fg = { rgb = [255, 255, 255] }
+
+# Selection - medium gray highlight
+selected_bg = { rgb = [60, 60, 60] }
+selected_fg = { rgb = [255, 255, 255] }
+
+# Disabled - bright enough to survive DIM modifier against black
+disabled = { rgb = [200, 200, 200] }
+
+# Semantic
+success = { rgb = [78, 201, 76] }
+warning = { rgb = [229, 192, 56] }
+error = { rgb = [232, 72, 85] }


### PR DESCRIPTION
## Summary

Adds a new built-in theme called **terminal** — pure black background with high-contrast text, matching the classic terminal look.

### Colors
| Role | Value | Notes |
|------|-------|-------|
| bg | `rgb(0, 0, 0)` | Pure black |
| fg | `rgb(204, 204, 204)` | Light gray text |
| accented_bg | `rgb(30, 30, 30)` | Dark gray headers |
| accented_fg | `rgb(255, 255, 255)` | White accent text |
| selected_bg | `rgb(60, 60, 60)` | Medium gray selection |
| selected_fg | `rgb(255, 255, 255)` | White selected text |
| disabled | `rgb(200, 200, 200)` | Bright enough to survive `Modifier::DIM` on black |
| success | `rgb(78, 201, 76)` | Green |
| warning | `rgb(229, 192, 56)` | Yellow |
| error | `rgb(232, 72, 85)` | Red |

### Files changed
- `crates/theme/themes/terminal.toml` — new theme definition
- `crates/theme/src/lib.rs` — register in built-in theme registry

## Test plan
- [x] Compiles cleanly
- [x] Theme appears in Alt+P > Themes picker
- [x] Git-ignored files readable with DIM modifier on black background
- [x] Tested on Windows 11