### PR TITLE
feat: shell picker submenu under Windows > Terminal

### DIFF
--- a/crates/app/src/app/menu_actions.rs
+++ b/crates/app/src/app/menu_actions.rs
@@ -619,6 +619,11 @@ impl App {
         &mut self,
         key: crossterm::event::KeyEvent,
     ) -> Result<()> {
+        // If shell picker nested submenu is open, delegate to it
+        if self.state.ui.tools_nested.open {
+            return self.handle_tools_nested_submenu_key(key);
+        }
+
         use termide_ui_render::TOOLS_SUBMENU_ITEM_COUNT;
 
         match navigate_submenu(
@@ -633,6 +638,33 @@ impl App {
         Ok(())
     }
 
+    /// Handle keyboard event in Tools nested submenu (shell picker)
+    fn handle_tools_nested_submenu_key(
+        &mut self,
+        key: crossterm::event::KeyEvent,
+    ) -> Result<()> {
+        let shells = termide_panel_terminal::shell_utils::discover_shells();
+        let item_count = shells.len();
+
+        match navigate_submenu(&key, &mut self.state.ui.tools_nested, item_count) {
+            SubmenuNavAction::Close => self.state.close_tools_nested_submenu(),
+            SubmenuNavAction::Execute => {
+                if let Some(shell) = shells.get(self.state.ui.tools_nested.selected) {
+                    let shell_path = shell.path.clone();
+                    // Save as default
+                    self.state.config.terminal.default_shell = Some(shell_path.clone());
+                    if let Err(e) = self.save_shell_preference(&shell_path) {
+                        log::warn!("Failed to save shell preference: {}", e);
+                    }
+                    self.state.close_menu();
+                    self.handle_new_terminal_with_shell(Some(&shell_path))?;
+                }
+            }
+            SubmenuNavAction::None => {}
+        }
+        Ok(())
+    }
+
     /// Execute action for selected Tools submenu item
     pub(super) fn execute_tools_submenu_action(&mut self) -> Result<()> {
         match self.state.ui.tools_submenu.selected {
@@ -642,9 +674,17 @@ impl App {
                 self.handle_new_file_manager()?;
             }
             1 => {
-                // Terminal - open new terminal panel
-                self.state.close_menu();
-                self.handle_new_terminal()?;
+                // Terminal - open shell picker submenu
+                let shells = termide_panel_terminal::shell_utils::discover_shells();
+                let default_idx = self
+                    .state
+                    .config
+                    .terminal
+                    .default_shell
+                    .as_ref()
+                    .and_then(|default| shells.iter().position(|s| s.path == *default))
+                    .unwrap_or(0);
+                self.state.open_tools_nested_submenu(default_idx);
             }
             2 => {
                 // Editor - open new editor panel

--- a/crates/app/src/app/menu_actions.rs
+++ b/crates/app/src/app/menu_actions.rs
@@ -639,16 +639,21 @@ impl App {
     }
 
     /// Handle keyboard event in Tools nested submenu (shell picker)
-    fn handle_tools_nested_submenu_key(
-        &mut self,
-        key: crossterm::event::KeyEvent,
-    ) -> Result<()> {
+    fn handle_tools_nested_submenu_key(&mut self, key: crossterm::event::KeyEvent) -> Result<()> {
         let item_count = self.state.cached_shells.len();
+        if item_count == 0 {
+            self.state.close_tools_nested_submenu();
+            return Ok(());
+        }
 
         match navigate_submenu(&key, &mut self.state.ui.tools_nested, item_count) {
             SubmenuNavAction::Close => self.state.close_tools_nested_submenu(),
             SubmenuNavAction::Execute => {
-                if let Some(shell) = self.state.cached_shells.get(self.state.ui.tools_nested.selected) {
+                if let Some(shell) = self
+                    .state
+                    .cached_shells
+                    .get(self.state.ui.tools_nested.selected)
+                {
                     let shell_path = shell.path.clone();
                     // Save as default
                     self.state.config.terminal.default_shell = Some(shell_path.clone());

--- a/crates/app/src/app/menu_actions.rs
+++ b/crates/app/src/app/menu_actions.rs
@@ -643,13 +643,12 @@ impl App {
         &mut self,
         key: crossterm::event::KeyEvent,
     ) -> Result<()> {
-        let shells = termide_panel_terminal::shell_utils::discover_shells();
-        let item_count = shells.len();
+        let item_count = self.state.cached_shells.len();
 
         match navigate_submenu(&key, &mut self.state.ui.tools_nested, item_count) {
             SubmenuNavAction::Close => self.state.close_tools_nested_submenu(),
             SubmenuNavAction::Execute => {
-                if let Some(shell) = shells.get(self.state.ui.tools_nested.selected) {
+                if let Some(shell) = self.state.cached_shells.get(self.state.ui.tools_nested.selected) {
                     let shell_path = shell.path.clone();
                     // Save as default
                     self.state.config.terminal.default_shell = Some(shell_path.clone());
@@ -674,17 +673,23 @@ impl App {
                 self.handle_new_file_manager()?;
             }
             1 => {
-                // Terminal - open shell picker submenu
-                let shells = termide_panel_terminal::shell_utils::discover_shells();
+                // Terminal - open shell picker submenu (caches shells on open)
+                self.state.open_tools_nested_submenu(0);
+                // Adjust selection to match the current default shell
                 let default_idx = self
                     .state
                     .config
                     .terminal
                     .default_shell
                     .as_ref()
-                    .and_then(|default| shells.iter().position(|s| s.path == *default))
+                    .and_then(|default| {
+                        self.state
+                            .cached_shells
+                            .iter()
+                            .position(|s| s.path == *default)
+                    })
                     .unwrap_or(0);
-                self.state.open_tools_nested_submenu(default_idx);
+                self.state.ui.tools_nested.selected = default_idx;
             }
             2 => {
                 // Editor - open new editor panel

--- a/crates/app/src/app/mouse_handler.rs
+++ b/crates/app/src/app/mouse_handler.rs
@@ -16,8 +16,8 @@ use termide_theme::Theme;
 use termide_ui_render::{
     get_bookmarks_group_items, get_bookmarks_items, get_menu_item_x_position, get_options_items,
     get_resource_indicator_ranges, get_scripts_group_items, get_scripts_items, get_sessions_items,
-    get_tools_items, MenuRenderParams, BOOKMARKS_MENU_INDEX, OPTIONS_MENU_INDEX,
-    SCRIPTS_MENU_INDEX, SESSIONS_MENU_INDEX, WINDOWS_MENU_INDEX,
+    get_shell_items, get_tools_items, MenuRenderParams, BOOKMARKS_MENU_INDEX,
+    OPTIONS_MENU_INDEX, SCRIPTS_MENU_INDEX, SESSIONS_MENU_INDEX, WINDOWS_MENU_INDEX,
 };
 
 /// Hit-test a dropdown menu and return the clicked item index (if any).
@@ -965,6 +965,36 @@ impl App {
     fn handle_tools_submenu_click(&mut self, x: u16, y: u16) -> Result<bool> {
         let menu_x = get_menu_item_x_position(WINDOWS_MENU_INDEX);
         let items = get_tools_items();
+
+        // If shell picker nested submenu is open, check clicks on it first
+        if self.state.ui.tools_nested.open {
+            let shells = termide_panel_terminal::shell_utils::discover_shells();
+            let shell_items = get_shell_items(
+                &shells,
+                self.state.config.terminal.default_shell.as_deref(),
+            );
+            if !shell_items.is_empty() {
+                // Calculate nested dropdown position (same as in ui.rs rendering)
+                let parent_width =
+                    items.iter().map(|i| i.label.width()).max().unwrap_or(10) as u16 + 4;
+                let nested_x = menu_x + parent_width;
+                let nested_y = 1 + 1 + 1; // dropdown_y + border + Terminal index
+                if let Some(index) = hit_dropdown_item(x, y, nested_x, nested_y, &shell_items) {
+                    if let Some(shell) = shells.get(index) {
+                        let shell_path = shell.path.clone();
+                        self.state.config.terminal.default_shell = Some(shell_path.clone());
+                        if let Err(e) = self.save_shell_preference(&shell_path) {
+                            log::warn!("Failed to save shell preference: {}", e);
+                        }
+                        self.state.close_menu();
+                        self.handle_new_terminal_with_shell(Some(&shell_path))?;
+                        return Ok(true);
+                    }
+                }
+            }
+        }
+
+        // Check click on Tools main dropdown
         if let Some(index) = hit_dropdown_item(x, y, menu_x, 1, &items) {
             self.state.ui.tools_submenu.selected = index;
             self.execute_tools_submenu_action()?;

--- a/crates/app/src/app/mouse_handler.rs
+++ b/crates/app/src/app/mouse_handler.rs
@@ -16,8 +16,8 @@ use termide_theme::Theme;
 use termide_ui_render::{
     get_bookmarks_group_items, get_bookmarks_items, get_menu_item_x_position, get_options_items,
     get_resource_indicator_ranges, get_scripts_group_items, get_scripts_items, get_sessions_items,
-    get_shell_items, get_tools_items, MenuRenderParams, BOOKMARKS_MENU_INDEX,
-    OPTIONS_MENU_INDEX, SCRIPTS_MENU_INDEX, SESSIONS_MENU_INDEX, WINDOWS_MENU_INDEX,
+    get_shell_items, get_tools_items, MenuRenderParams, BOOKMARKS_MENU_INDEX, OPTIONS_MENU_INDEX,
+    SCRIPTS_MENU_INDEX, SESSIONS_MENU_INDEX, WINDOWS_MENU_INDEX,
 };
 
 /// Hit-test a dropdown menu and return the clicked item index (if any).

--- a/crates/app/src/app/mouse_handler.rs
+++ b/crates/app/src/app/mouse_handler.rs
@@ -968,19 +968,19 @@ impl App {
 
         // If shell picker nested submenu is open, check clicks on it first
         if self.state.ui.tools_nested.open {
-            let shells = termide_panel_terminal::shell_utils::discover_shells();
             let shell_items = get_shell_items(
-                &shells,
+                &self.state.cached_shells,
                 self.state.config.terminal.default_shell.as_deref(),
             );
             if !shell_items.is_empty() {
-                // Calculate nested dropdown position (same as in ui.rs rendering)
+                // Calculate nested dropdown position (same formula as in ui.rs rendering)
+                let dropdown_y = 1_u16;
                 let parent_width =
                     items.iter().map(|i| i.label.width()).max().unwrap_or(10) as u16 + 4;
                 let nested_x = menu_x + parent_width;
-                let nested_y = 1 + 1 + 1; // dropdown_y + border + Terminal index
+                let nested_y = dropdown_y + 1 + self.state.ui.tools_submenu.selected as u16;
                 if let Some(index) = hit_dropdown_item(x, y, nested_x, nested_y, &shell_items) {
-                    if let Some(shell) = shells.get(index) {
+                    if let Some(shell) = self.state.cached_shells.get(index) {
                         let shell_path = shell.path.clone();
                         self.state.config.terminal.default_shell = Some(shell_path.clone());
                         if let Err(e) = self.save_shell_preference(&shell_path) {

--- a/crates/app/src/app/panel_factory.rs
+++ b/crates/app/src/app/panel_factory.rs
@@ -14,9 +14,18 @@ use termide_panel_misc::{HelpPanel as Help, JournalPanel as Journal};
 use termide_panel_terminal::Terminal;
 
 impl App {
-    /// Create new terminal
+    /// Create new terminal using the default shell (from config or auto-detect)
     pub(super) fn handle_new_terminal(&mut self) -> Result<()> {
-        log::debug!("Opening new Terminal panel");
+        let shell = self.state.config.terminal.default_shell.clone();
+        self.handle_new_terminal_with_shell(shell.as_deref())
+    }
+
+    /// Create new terminal with a specific shell (or auto-detect if None)
+    pub(super) fn handle_new_terminal_with_shell(
+        &mut self,
+        shell_path: Option<&str>,
+    ) -> Result<()> {
+        log::debug!("Opening new Terminal panel with shell: {:?}", shell_path);
         self.close_help_panels();
         // Get working directory from current active panel
         let working_dir = self
@@ -30,10 +39,23 @@ impl App {
         let term_height = height.saturating_sub(3);
         let term_width = width.saturating_sub(2);
 
-        if let Ok(terminal_panel) = Terminal::new_with_cwd(term_height, term_width, working_dir) {
+        let result = match shell_path {
+            Some(path) => Terminal::new_with_shell(term_height, term_width, path, working_dir),
+            None => Terminal::new_with_cwd(term_height, term_width, working_dir),
+        };
+
+        if let Ok(terminal_panel) = result {
             self.add_panel(Box::new(terminal_panel));
             self.auto_save_session();
         }
+        Ok(())
+    }
+
+    /// Save shell preference to config file
+    pub(super) fn save_shell_preference(&self, shell_path: &str) -> Result<()> {
+        let mut config = termide_config::Config::load()?;
+        config.terminal.default_shell = Some(shell_path.to_string());
+        config.save()?;
         Ok(())
     }
 

--- a/crates/app/src/state.rs
+++ b/crates/app/src/state.rs
@@ -272,6 +272,8 @@ pub struct AppState {
     pub batch_sub_operation_id: Option<termide_file_ops::OperationId>,
     /// Counter for generating synthetic batch operation IDs.
     batch_id_counter: u64,
+    /// Cached shell list for the shell picker submenu (populated on open, cleared on close).
+    pub cached_shells: Vec<termide_panel_terminal::shell_utils::ShellInfo>,
 }
 
 impl Default for AppState {
@@ -352,6 +354,7 @@ impl AppState {
             batch_tracking_id: None,
             batch_sub_operation_id: None,
             batch_id_counter: u64::MAX / 2,
+            cached_shells: Vec::new(),
         }
     }
 
@@ -432,16 +435,19 @@ impl AppState {
     pub fn close_tools_submenu(&mut self) {
         self.ui.tools_submenu.close();
         self.ui.tools_nested.close();
+        self.cached_shells.clear();
     }
 
-    /// Open Tools nested submenu (shell picker)
+    /// Open Tools nested submenu (shell picker) and cache the shell list
     pub fn open_tools_nested_submenu(&mut self, initial_item: usize) {
+        self.cached_shells = termide_panel_terminal::shell_utils::discover_shells();
         self.ui.tools_nested.open_at(initial_item);
     }
 
-    /// Close Tools nested submenu
+    /// Close Tools nested submenu and clear cached shells
     pub fn close_tools_nested_submenu(&mut self) {
         self.ui.tools_nested.close();
+        self.cached_shells.clear();
     }
 
     /// Open Scripts submenu

--- a/crates/app/src/state.rs
+++ b/crates/app/src/state.rs
@@ -431,6 +431,17 @@ impl AppState {
     /// Close Tools submenu
     pub fn close_tools_submenu(&mut self) {
         self.ui.tools_submenu.close();
+        self.ui.tools_nested.close();
+    }
+
+    /// Open Tools nested submenu (shell picker)
+    pub fn open_tools_nested_submenu(&mut self, initial_item: usize) {
+        self.ui.tools_nested.open_at(initial_item);
+    }
+
+    /// Close Tools nested submenu
+    pub fn close_tools_nested_submenu(&mut self) {
+        self.ui.tools_nested.close();
     }
 
     /// Open Scripts submenu

--- a/crates/config/src/settings.rs
+++ b/crates/config/src/settings.rs
@@ -167,6 +167,9 @@ pub struct GitStatusSettings {
 /// Terminal panel settings.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct TerminalSettings {
+    /// Default shell path (None = auto-detect)
+    #[serde(default)]
+    pub default_shell: Option<String>,
     /// Terminal keyboard shortcuts
     #[serde(default)]
     pub keybindings: TerminalKeybindings,

--- a/crates/panel-terminal/src/lib.rs
+++ b/crates/panel-terminal/src/lib.rs
@@ -4,7 +4,7 @@
 mod clipboard;
 mod disk_space;
 mod link_detection;
-mod shell_utils;
+pub mod shell_utils;
 mod terminal;
 mod terminal_info;
 
@@ -241,6 +241,87 @@ impl Terminal {
         cmd.cwd(&working_dir);
         Self::set_env(&mut cmd, &working_dir);
         cmd.env("SHELL", &shell);
+
+        let child = pair.slave.spawn_command(cmd)?;
+        let shell_pid = child.process_id();
+        let screen = Arc::new(RwLock::new(TerminalScreen::new(
+            rows as usize,
+            cols as usize,
+        )));
+        let reader = pair.master.try_clone_reader()?;
+        let writer = pair.master.take_writer()?;
+        let pty = Arc::new(Mutex::new(pair.master));
+        let is_alive = Arc::new(Mutex::new(true));
+        let has_new_data = Arc::new(AtomicBool::new(false));
+
+        Self::spawn_reader(reader, &screen, &is_alive, &has_new_data);
+
+        let username = std::env::var("USER")
+            .or_else(|_| std::env::var("USERNAME"))
+            .unwrap_or_else(|_| "user".to_string());
+        let hostname = std::env::var("HOSTNAME")
+            .or_else(|_| std::env::var("HOST"))
+            .unwrap_or_else(|_| "localhost".to_string());
+        let current_dir = std::env::current_dir()
+            .ok()
+            .and_then(|p| p.file_name().map(|n| n.to_string_lossy().to_string()))
+            .unwrap_or_else(|| "~".to_string());
+        let title_prefix = format!("{}@{}//{}", username, hostname, current_dir);
+
+        let mut term = Self::build(
+            pty,
+            writer,
+            child,
+            shell_pid,
+            screen,
+            size,
+            is_alive,
+            has_new_data,
+        );
+        term.title_prefix = title_prefix;
+        term.initial_cwd = working_dir;
+        Ok(term)
+    }
+
+    /// Create new terminal with a specific shell and optional working directory.
+    pub fn new_with_shell(
+        rows: u16,
+        cols: u16,
+        shell_path: &str,
+        cwd: Option<std::path::PathBuf>,
+    ) -> Result<Self> {
+        let pty_system = native_pty_system();
+        let size = PtySize {
+            rows,
+            cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        };
+        let pair = pty_system.openpty(size)?;
+
+        let shell_args = shell_utils::get_shell_args(shell_path);
+
+        // WSL entries use "wsl -d distro" format
+        let mut cmd = if shell_path.starts_with("wsl ") {
+            let parts: Vec<&str> = shell_path.split_whitespace().collect();
+            let mut cmd = CommandBuilder::new(parts[0]);
+            for arg in &parts[1..] {
+                cmd.arg(arg);
+            }
+            cmd
+        } else {
+            let mut cmd = CommandBuilder::new(shell_path);
+            for arg in shell_args {
+                cmd.arg(arg);
+            }
+            cmd
+        };
+
+        let working_dir =
+            cwd.unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| "/".into()));
+        cmd.cwd(&working_dir);
+        Self::set_env(&mut cmd, &working_dir);
+        cmd.env("SHELL", shell_path);
 
         let child = pair.slave.spawn_command(cmd)?;
         let shell_pid = child.process_id();

--- a/crates/panel-terminal/src/lib.rs
+++ b/crates/panel-terminal/src/lib.rs
@@ -243,6 +243,9 @@ impl Terminal {
         // WSL entries use "wsl -d distro" format
         let mut cmd = if shell_path.starts_with("wsl ") {
             let parts: Vec<&str> = shell_path.split_whitespace().collect();
+            if parts.is_empty() {
+                anyhow::bail!("empty shell path");
+            }
             let mut cmd = CommandBuilder::new(parts[0]);
             for arg in &parts[1..] {
                 cmd.arg(arg);

--- a/crates/panel-terminal/src/lib.rs
+++ b/crates/panel-terminal/src/lib.rs
@@ -216,71 +216,10 @@ impl Terminal {
         }
     }
 
-    /// Create new terminal with specified working directory
+    /// Create new terminal with specified working directory (auto-detects shell)
     pub fn new_with_cwd(rows: u16, cols: u16, cwd: Option<std::path::PathBuf>) -> Result<Self> {
-        let pty_system = native_pty_system();
-        let size = PtySize {
-            rows,
-            cols,
-            pixel_width: 0,
-            pixel_height: 0,
-        };
-        let pair = pty_system.openpty(size)?;
-
-        // Detect shell
         let shell = shell_utils::detect_shell();
-        let shell_args = shell_utils::get_shell_args(&shell);
-
-        let mut cmd = CommandBuilder::new(&shell);
-        for arg in shell_args {
-            cmd.arg(arg);
-        }
-
-        let working_dir =
-            cwd.unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| "/".into()));
-        cmd.cwd(&working_dir);
-        Self::set_env(&mut cmd, &working_dir);
-        cmd.env("SHELL", &shell);
-
-        let child = pair.slave.spawn_command(cmd)?;
-        let shell_pid = child.process_id();
-        let screen = Arc::new(RwLock::new(TerminalScreen::new(
-            rows as usize,
-            cols as usize,
-        )));
-        let reader = pair.master.try_clone_reader()?;
-        let writer = pair.master.take_writer()?;
-        let pty = Arc::new(Mutex::new(pair.master));
-        let is_alive = Arc::new(Mutex::new(true));
-        let has_new_data = Arc::new(AtomicBool::new(false));
-
-        Self::spawn_reader(reader, &screen, &is_alive, &has_new_data);
-
-        let username = std::env::var("USER")
-            .or_else(|_| std::env::var("USERNAME"))
-            .unwrap_or_else(|_| "user".to_string());
-        let hostname = std::env::var("HOSTNAME")
-            .or_else(|_| std::env::var("HOST"))
-            .unwrap_or_else(|_| "localhost".to_string());
-        let current_dir = std::env::current_dir()
-            .ok()
-            .and_then(|p| p.file_name().map(|n| n.to_string_lossy().to_string()))
-            .unwrap_or_else(|| "~".to_string());
-        let title_prefix = format!("{}@{}//{}", username, hostname, current_dir);
-
-        let mut term = Self::build(
-            pty,
-            writer,
-            child,
-            shell_pid,
-            screen,
-            size,
-            is_alive,
-            has_new_data,
-        );
-        term.title_prefix = title_prefix;
-        term.initial_cwd = working_dir;
-        Ok(term)
+        Self::new_with_shell(rows, cols, &shell, cwd)
     }
 
     /// Create new terminal with a specific shell and optional working directory.

--- a/crates/panel-terminal/src/shell_utils.rs
+++ b/crates/panel-terminal/src/shell_utils.rs
@@ -3,6 +3,205 @@
 //! This module provides functions for detecting available shells
 //! and determining appropriate arguments for launching them.
 
+/// Information about an available shell.
+#[derive(Debug, Clone)]
+pub struct ShellInfo {
+    /// Friendly display name (e.g. "Git Bash", "PowerShell Core")
+    pub name: String,
+    /// Full path to shell binary (or launch command for WSL)
+    pub path: String,
+}
+
+/// Discover all available shells on the system.
+///
+/// Returns a list of shells with friendly names, ordered by preference.
+pub fn discover_shells() -> Vec<ShellInfo> {
+    let mut shells = Vec::new();
+    let mut seen_paths: Vec<String> = Vec::new();
+
+    #[cfg(windows)]
+    {
+        // Git Bash at standard install locations
+        let git_bash_paths = [
+            r"C:\Program Files\Git\bin\bash.exe",
+            r"C:\Program Files (x86)\Git\bin\bash.exe",
+        ];
+        for path in &git_bash_paths {
+            if std::path::Path::new(path).exists() && !seen_contains(&seen_paths, path) {
+                shells.push(ShellInfo {
+                    name: "Git Bash".to_string(),
+                    path: path.to_string(),
+                });
+                seen_paths.push(path.to_lowercase());
+                break; // Only add one Git Bash
+            }
+        }
+
+        // Bash on PATH (MSYS2, custom installs — skip if already found as Git Bash)
+        if let Some(path) = where_first("bash.exe") {
+            if !seen_contains(&seen_paths, &path) {
+                shells.push(ShellInfo {
+                    name: "Bash".to_string(),
+                    path: path.clone(),
+                });
+                seen_paths.push(path.to_lowercase());
+            }
+        }
+
+        // PowerShell Core (pwsh)
+        if let Some(path) = where_first("pwsh.exe") {
+            if !seen_contains(&seen_paths, &path) {
+                shells.push(ShellInfo {
+                    name: "PowerShell Core".to_string(),
+                    path: path.clone(),
+                });
+                seen_paths.push(path.to_lowercase());
+            }
+        }
+
+        // Windows PowerShell
+        if let Some(path) = where_first("powershell.exe") {
+            if !seen_contains(&seen_paths, &path) {
+                shells.push(ShellInfo {
+                    name: "Windows PowerShell".to_string(),
+                    path: path.clone(),
+                });
+                seen_paths.push(path.to_lowercase());
+            }
+        }
+
+        // Command Prompt
+        let cmd = std::env::var("COMSPEC").unwrap_or_else(|_| "cmd.exe".to_string());
+        if !seen_contains(&seen_paths, &cmd) {
+            shells.push(ShellInfo {
+                name: "Command Prompt".to_string(),
+                path: cmd.clone(),
+            });
+            seen_paths.push(cmd.to_lowercase());
+        }
+
+        // WSL distributions
+        if let Ok(output) = std::process::Command::new("wsl")
+            .args(["--list", "--quiet"])
+            .output()
+        {
+            if output.status.success() {
+                // WSL output may be UTF-16LE on some Windows versions
+                let text = String::from_utf8(output.stdout)
+                    .or_else(|e| {
+                        let bytes = e.into_bytes();
+                        // Try UTF-16LE decoding
+                        let u16s: Vec<u16> = bytes
+                            .chunks_exact(2)
+                            .map(|c| u16::from_le_bytes([c[0], c[1]]))
+                            .collect();
+                        String::from_utf16(&u16s).map_err(|_| ())
+                    })
+                    .unwrap_or_default();
+
+                for line in text.lines() {
+                    let distro = line.trim().trim_start_matches('\u{feff}'); // strip BOM
+                    if !distro.is_empty() {
+                        shells.push(ShellInfo {
+                            name: format!("WSL: {}", distro),
+                            path: format!("wsl -d {}", distro),
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    #[cfg(not(windows))]
+    {
+        // Parse /etc/shells for all valid login shells
+        if let Ok(content) = std::fs::read_to_string("/etc/shells") {
+            for line in content.lines() {
+                let line = line.trim();
+                if line.starts_with('#') || line.is_empty() {
+                    continue;
+                }
+                if std::path::Path::new(line).exists() && !seen_contains(&seen_paths, line) {
+                    shells.push(ShellInfo {
+                        name: shell_display_name(line),
+                        path: line.to_string(),
+                    });
+                    seen_paths.push(line.to_string());
+                }
+            }
+        }
+
+        // Also check NixOS paths and common paths not in /etc/shells
+        let extra_paths = [
+            "/run/current-system/sw/bin/fish",
+            "/run/current-system/sw/bin/zsh",
+            "/run/current-system/sw/bin/bash",
+            "/usr/bin/fish",
+            "/usr/bin/zsh",
+            "/bin/bash",
+            "/bin/sh",
+        ];
+        for path in extra_paths {
+            if std::path::Path::new(path).exists() && !seen_contains(&seen_paths, path) {
+                shells.push(ShellInfo {
+                    name: shell_display_name(path),
+                    path: path.to_string(),
+                });
+                seen_paths.push(path.to_string());
+            }
+        }
+    }
+
+    shells
+}
+
+/// Get a friendly display name for a shell path.
+#[cfg(not(windows))]
+fn shell_display_name(path: &str) -> String {
+    let name = std::path::Path::new(path)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(path);
+
+    // Capitalize first letter
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(c) => format!("{}{}", c.to_uppercase(), chars.as_str()),
+        None => name.to_string(),
+    }
+}
+
+/// Check if a path is already in the seen list (case-insensitive on Windows).
+fn seen_contains(seen: &[String], path: &str) -> bool {
+    #[cfg(windows)]
+    {
+        let lower = path.to_lowercase();
+        seen.iter().any(|s| s == &lower)
+    }
+    #[cfg(not(windows))]
+    {
+        seen.iter().any(|s| s == path)
+    }
+}
+
+/// Run `where` on Windows and return the first result.
+#[cfg(windows)]
+fn where_first(binary: &str) -> Option<String> {
+    let output = std::process::Command::new("where")
+        .arg(binary)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let text = String::from_utf8(output.stdout).ok()?;
+    let path = text.trim();
+    if path.is_empty() {
+        return None;
+    }
+    Some(path.lines().next().unwrap_or(path).to_string())
+}
+
 /// Detect available shell on the system.
 ///
 /// Checks in order:

--- a/crates/panel-terminal/src/shell_utils.rs
+++ b/crates/panel-terminal/src/shell_utils.rs
@@ -17,7 +17,7 @@ pub struct ShellInfo {
 /// Returns a list of shells with friendly names, ordered by preference.
 pub fn discover_shells() -> Vec<ShellInfo> {
     let mut shells = Vec::new();
-    let mut seen_paths: Vec<String> = Vec::new();
+    let mut seen_paths = std::collections::HashSet::new();
 
     #[cfg(windows)]
     {
@@ -32,7 +32,7 @@ pub fn discover_shells() -> Vec<ShellInfo> {
                     name: "Git Bash".to_string(),
                     path: path.to_string(),
                 });
-                seen_paths.push(path.to_lowercase());
+                seen_paths.insert(path.to_lowercase());
                 break; // Only add one Git Bash
             }
         }
@@ -44,7 +44,7 @@ pub fn discover_shells() -> Vec<ShellInfo> {
                     name: "Bash".to_string(),
                     path: path.clone(),
                 });
-                seen_paths.push(path.to_lowercase());
+                seen_paths.insert(path.to_lowercase());
             }
         }
 
@@ -55,7 +55,7 @@ pub fn discover_shells() -> Vec<ShellInfo> {
                     name: "PowerShell Core".to_string(),
                     path: path.clone(),
                 });
-                seen_paths.push(path.to_lowercase());
+                seen_paths.insert(path.to_lowercase());
             }
         }
 
@@ -66,7 +66,7 @@ pub fn discover_shells() -> Vec<ShellInfo> {
                     name: "Windows PowerShell".to_string(),
                     path: path.clone(),
                 });
-                seen_paths.push(path.to_lowercase());
+                seen_paths.insert(path.to_lowercase());
             }
         }
 
@@ -77,7 +77,7 @@ pub fn discover_shells() -> Vec<ShellInfo> {
                 name: "Command Prompt".to_string(),
                 path: cmd.clone(),
             });
-            seen_paths.push(cmd.to_lowercase());
+            seen_paths.insert(cmd.to_lowercase());
         }
 
         // WSL distributions
@@ -126,7 +126,7 @@ pub fn discover_shells() -> Vec<ShellInfo> {
                         name: shell_display_name(line),
                         path: line.to_string(),
                     });
-                    seen_paths.push(line.to_string());
+                    seen_paths.insert(line.to_string());
                 }
             }
         }
@@ -147,7 +147,7 @@ pub fn discover_shells() -> Vec<ShellInfo> {
                     name: shell_display_name(path),
                     path: path.to_string(),
                 });
-                seen_paths.push(path.to_string());
+                seen_paths.insert(path.to_string());
             }
         }
     }
@@ -171,16 +171,15 @@ fn shell_display_name(path: &str) -> String {
     }
 }
 
-/// Check if a path is already in the seen list (case-insensitive on Windows).
-fn seen_contains(seen: &[String], path: &str) -> bool {
+/// Check if a path is already in the seen set (case-insensitive on Windows).
+fn seen_contains(seen: &std::collections::HashSet<String>, path: &str) -> bool {
     #[cfg(windows)]
     {
-        let lower = path.to_lowercase();
-        seen.iter().any(|s| s == &lower)
+        seen.contains(&path.to_lowercase())
     }
     #[cfg(not(windows))]
     {
-        seen.iter().any(|s| s == path)
+        seen.contains(path)
     }
 }
 

--- a/crates/panel-terminal/src/shell_utils.rs
+++ b/crates/panel-terminal/src/shell_utils.rs
@@ -90,8 +90,9 @@ pub fn discover_shells() -> Vec<ShellInfo> {
                 let text = String::from_utf8(output.stdout)
                     .or_else(|e| {
                         let bytes = e.into_bytes();
-                        // Try UTF-16LE decoding
-                        let u16s: Vec<u16> = bytes
+                        // Try UTF-16LE decoding; truncate trailing odd byte if present
+                        let len = bytes.len() & !1;
+                        let u16s: Vec<u16> = bytes[..len]
                             .chunks_exact(2)
                             .map(|c| u16::from_le_bytes([c[0], c[1]]))
                             .collect();

--- a/crates/state/src/ui.rs
+++ b/crates/state/src/ui.rs
@@ -119,6 +119,8 @@ pub struct UiState {
     pub sessions_submenu: SubmenuState,
     /// Tools submenu state
     pub tools_submenu: SubmenuState,
+    /// Tools nested submenu state (shell picker inside Terminal)
+    pub tools_nested: SubmenuState,
     /// Scripts submenu state
     pub scripts_submenu: SubmenuState,
     /// Scripts nested submenu state (for subdirectory groups)
@@ -143,6 +145,7 @@ impl UiState {
     pub fn close_all_submenus(&mut self) {
         self.sessions_submenu.close();
         self.tools_submenu.close();
+        self.tools_nested.close();
         self.options_submenu.close();
         self.nested_submenu.close();
         self.scripts_submenu.close();
@@ -284,6 +287,7 @@ mod tests {
         let mut ui = UiState::default();
         ui.sessions_submenu.open();
         ui.tools_submenu.open();
+        ui.tools_nested.open();
         ui.options_submenu.open();
         ui.scripts_submenu.open();
         ui.bookmarks_submenu.open();
@@ -294,6 +298,7 @@ mod tests {
 
         assert!(!ui.sessions_submenu.open);
         assert!(!ui.tools_submenu.open);
+        assert!(!ui.tools_nested.open);
         assert!(!ui.options_submenu.open);
         assert!(!ui.scripts_submenu.open);
         assert!(!ui.bookmarks_submenu.open);

--- a/crates/ui-render/src/dropdown.rs
+++ b/crates/ui-render/src/dropdown.rs
@@ -212,7 +212,7 @@ pub fn get_tools_items() -> Vec<DropdownItem> {
     let t = i18n::t();
     vec![
         DropdownItem::new(t.tools_files(), "files"),
-        DropdownItem::new(t.tools_terminal(), "terminal"),
+        DropdownItem::new(t.tools_terminal(), "terminal").with_submenu(),
         DropdownItem::new(t.tools_editor(), "editor"),
         DropdownItem::new(t.tools_git_status(), "git_status"),
         DropdownItem::new(t.tools_git_log(), "git_log"),
@@ -225,6 +225,29 @@ pub fn get_tools_items() -> Vec<DropdownItem> {
 
 /// Number of items in Tools submenu
 pub const TOOLS_SUBMENU_ITEM_COUNT: usize = 9;
+
+/// Get shell picker submenu items from discovered shells.
+///
+/// Marks the default shell with a `●` indicator.
+pub fn get_shell_items(
+    shells: &[termide_panel_terminal::shell_utils::ShellInfo],
+    default_shell: Option<&str>,
+) -> Vec<DropdownItem> {
+    shells
+        .iter()
+        .map(|shell| {
+            let is_default = default_shell
+                .map(|d| d == shell.path)
+                .unwrap_or(false);
+            let label = if is_default {
+                format!("{} ●", shell.name)
+            } else {
+                shell.name.clone()
+            };
+            DropdownItem::new(label, &shell.path)
+        })
+        .collect()
+}
 
 /// Get options submenu items
 pub fn get_options_items() -> Vec<DropdownItem> {

--- a/crates/ui-render/src/dropdown.rs
+++ b/crates/ui-render/src/dropdown.rs
@@ -236,9 +236,7 @@ pub fn get_shell_items(
     shells
         .iter()
         .map(|shell| {
-            let is_default = default_shell
-                .map(|d| d == shell.path)
-                .unwrap_or(false);
+            let is_default = default_shell.map(|d| d == shell.path).unwrap_or(false);
             let label = if is_default {
                 format!("{} ●", shell.name)
             } else {

--- a/crates/ui-render/src/lib.rs
+++ b/crates/ui-render/src/lib.rs
@@ -12,9 +12,9 @@ pub mod theme_dropdown;
 
 pub use dropdown::{
     get_bookmarks_group_items, get_bookmarks_item_count, get_bookmarks_items, get_options_items,
-    get_scripts_group_items, get_scripts_items, get_sessions_items, get_tools_items, Dropdown,
-    DropdownItem, BOOKMARK_ADD_CURRENT, OPTIONS_SUBMENU_ITEM_COUNT, SCRIPT_ADD_NEW,
-    SESSIONS_SUBMENU_ITEM_COUNT, TOOLS_SUBMENU_ITEM_COUNT,
+    get_scripts_group_items, get_scripts_items, get_sessions_items, get_shell_items,
+    get_tools_items, Dropdown, DropdownItem, BOOKMARK_ADD_CURRENT, OPTIONS_SUBMENU_ITEM_COUNT,
+    SCRIPT_ADD_NEW, SESSIONS_SUBMENU_ITEM_COUNT, TOOLS_SUBMENU_ITEM_COUNT,
 };
 pub use inline_selector::InlineSelector;
 pub use language_dropdown::{find_current_language_index, LanguageDropdown};

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -71,15 +71,14 @@ fn render_dropdowns_and_modals(frame: &mut Frame, state: &mut AppState) {
 
         // Render shell picker nested submenu if open (Terminal selected)
         if state.ui.tools_nested.open && state.ui.tools_submenu.selected == 1 {
-            let shells = termide_panel_terminal::shell_utils::discover_shells();
             let shell_items = get_shell_items(
-                &shells,
+                &state.cached_shells,
                 state.config.terminal.default_shell.as_deref(),
             );
             if !shell_items.is_empty() {
                 let nested_x = menu_x + dropdown.width();
-                // Position at Terminal item row (index 1 + 1 for border)
-                let nested_y = dropdown_y + 1 + 1;
+                // +1 for border, +selected for the item row
+                let nested_y = dropdown_y + 1 + state.ui.tools_submenu.selected as u16;
                 let nested_dropdown = Dropdown::new(
                     &shell_items,
                     state.ui.tools_nested.selected,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -15,7 +15,8 @@ use termide_panel_terminal::Terminal;
 use termide_theme::Theme;
 use termide_ui_render::{
     get_bookmarks_group_items, get_bookmarks_items, get_menu_item_x_position, get_options_items,
-    get_scripts_group_items, get_scripts_items, get_sessions_items, get_tools_items,
+    get_scripts_group_items, get_scripts_items, get_sessions_items, get_shell_items,
+    get_tools_items,
     render_collapsed_panel, render_dividers, render_expanded_panel, render_menu, Dropdown,
     ExpandedPanelParams, LanguageDropdown, MenuRenderParams, ThemeDropdown, BOOKMARKS_MENU_INDEX,
     OPTIONS_MENU_INDEX, SCRIPTS_MENU_INDEX, SESSIONS_MENU_INDEX, WINDOWS_MENU_INDEX,
@@ -67,6 +68,28 @@ fn render_dropdowns_and_modals(frame: &mut Frame, state: &mut AppState) {
             theme,
         );
         dropdown.render(frame.buffer_mut());
+
+        // Render shell picker nested submenu if open (Terminal selected)
+        if state.ui.tools_nested.open && state.ui.tools_submenu.selected == 1 {
+            let shells = termide_panel_terminal::shell_utils::discover_shells();
+            let shell_items = get_shell_items(
+                &shells,
+                state.config.terminal.default_shell.as_deref(),
+            );
+            if !shell_items.is_empty() {
+                let nested_x = menu_x + dropdown.width();
+                // Position at Terminal item row (index 1 + 1 for border)
+                let nested_y = dropdown_y + 1 + 1;
+                let nested_dropdown = Dropdown::new(
+                    &shell_items,
+                    state.ui.tools_nested.selected,
+                    nested_x,
+                    nested_y,
+                    theme,
+                );
+                nested_dropdown.render(frame.buffer_mut());
+            }
+        }
     }
 
     // Render Scripts submenu if open

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -16,10 +16,10 @@ use termide_theme::Theme;
 use termide_ui_render::{
     get_bookmarks_group_items, get_bookmarks_items, get_menu_item_x_position, get_options_items,
     get_scripts_group_items, get_scripts_items, get_sessions_items, get_shell_items,
-    get_tools_items,
-    render_collapsed_panel, render_dividers, render_expanded_panel, render_menu, Dropdown,
-    ExpandedPanelParams, LanguageDropdown, MenuRenderParams, ThemeDropdown, BOOKMARKS_MENU_INDEX,
-    OPTIONS_MENU_INDEX, SCRIPTS_MENU_INDEX, SESSIONS_MENU_INDEX, WINDOWS_MENU_INDEX,
+    get_tools_items, render_collapsed_panel, render_dividers, render_expanded_panel, render_menu,
+    Dropdown, ExpandedPanelParams, LanguageDropdown, MenuRenderParams, ThemeDropdown,
+    BOOKMARKS_MENU_INDEX, OPTIONS_MENU_INDEX, SCRIPTS_MENU_INDEX, SESSIONS_MENU_INDEX,
+    WINDOWS_MENU_INDEX,
 };
 
 use termide_ui_render::{StatusBar, StatusBarParams};


### PR DESCRIPTION
## Summary

Clicking **Terminal** in the Windows menu now opens a nested submenu listing all available shells on the system (similar to how Options > Themes works). Selecting a shell opens a terminal with it and saves it as the default.

Also adds `default_shell` option to `[terminal]` config section. The Alt+T shortcut uses the saved default shell.

### Shell discovery

**Windows:** Git Bash, PowerShell Core, Windows PowerShell, Command Prompt, WSL distributions (via `wsl --list --quiet`)

**Linux/macOS:** Parses `/etc/shells`, checks NixOS paths and common shell locations. Friendly names derived from binary filename.

### Files changed (11)

| File | Change |
|------|--------|
| `crates/panel-terminal/src/shell_utils.rs` | Add `ShellInfo`, `discover_shells()`, helper functions |
| `crates/panel-terminal/src/lib.rs` | Make `shell_utils` public, add `Terminal::new_with_shell()` with WSL support |
| `crates/config/src/settings.rs` | Add `default_shell: Option<String>` to `TerminalSettings` |
| `crates/state/src/ui.rs` | Add `tools_nested: SubmenuState`, update `close_all_submenus()` |
| `crates/app/src/state.rs` | Add `open_tools_nested_submenu()` / `close_tools_nested_submenu()` |
| `crates/app/src/app/panel_factory.rs` | Add `handle_new_terminal_with_shell()`, `save_shell_preference()` |
| `crates/app/src/app/menu_actions.rs` | Shell picker keyboard navigation, Terminal opens submenu instead of direct terminal |
| `crates/app/src/app/mouse_handler.rs` | Click support for nested shell picker dropdown |
| `crates/ui-render/src/dropdown.rs` | Mark Terminal with submenu arrow, add `get_shell_items()` |
| `crates/ui-render/src/lib.rs` | Export `get_shell_items` |
| `src/ui.rs` | Render shell picker dropdown next to Tools dropdown |

## Test plan
- [x] Compiles with zero warnings
- [x] All 30 state/terminal tests pass
- [x] Tested on Windows 11 — Git Bash, PowerShell, Command Prompt, WSL all appear
- [x] Selecting a shell opens a working terminal
- [x] Selected shell saved as default (persists across sessions)
- [ ] Verify on Linux (shell discovery from /etc/shells)
- [ ] Verify on macOS