### PR TITLE
fix: handle held-key repeat under kitty protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to TermIDE will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Held-key auto-repeat on Kitty-protocol terminals.** When the terminal supports the Kitty keyboard protocol, termide enables `REPORT_EVENT_TYPES`, so a held key streams `Repeat` events. The event handler previously discarded `Repeat` along with `Release`. `Repeat` is now treated like `Press`, restoring auto-repeat.
+
 ## [0.24.0] - 2026-06-07
 
 ### Added

--- a/crates/core/src/event.rs
+++ b/crates/core/src/event.rs
@@ -72,13 +72,15 @@ impl EventHandler {
 
         if event::poll(self.tick_rate)? {
             match event::read()? {
-                // With kitty keyboard protocol, we receive Press, Release, and Repeat events.
-                // Only handle Press events to avoid duplicate actions.
-                CrosstermEvent::Key(key) if key.kind == KeyEventKind::Press => {
+                // Handle Press and Repeat (held-key auto-repeat) so navigation/resize
+                // keeps firing while key is down.
+                CrosstermEvent::Key(key)
+                    if matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) =>
+                {
                     self.try_coalesce_paste(key)
                 }
                 CrosstermEvent::Key(_) => {
-                    // Release/Repeat from REPORT_EVENT_TYPES — drain buffered
+                    // Release from REPORT_EVENT_TYPES — drain buffered
                     // events with zero timeout instead of generating a spurious
                     // Tick that triggers the full background-processing pipeline.
                     self.drain_non_press_keys()
@@ -181,13 +183,15 @@ impl EventHandler {
         Ok(Event::Mouse(latest))
     }
 
-    /// Drain buffered Release/Repeat key events left by REPORT_EVENT_TYPES.
-    /// Returns the first real event found (Press key, mouse, resize…) or Tick
-    /// when the queue is empty.
+    /// Drain buffered Release key events left by REPORT_EVENT_TYPES.
+    /// Returns the first real event found (Press/Repeat key, mouse, resize…) or
+    /// Tick when the queue is empty.
     fn drain_non_press_keys(&self) -> Result<Event> {
         while event::poll(Duration::ZERO)? {
             match event::read()? {
-                CrosstermEvent::Key(key) if key.kind == KeyEventKind::Press => {
+                CrosstermEvent::Key(key)
+                    if matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) =>
+                {
                     return self.try_coalesce_paste(key);
                 }
                 CrosstermEvent::Key(_) => continue,
@@ -287,14 +291,66 @@ impl EventHandler {
     /// Convert crossterm event to our Event type.
     fn convert_crossterm_event(&self, raw: CrosstermEvent) -> Option<Event> {
         match raw {
-            CrosstermEvent::Key(key) if key.kind == KeyEventKind::Press => Some(Event::Key(key)),
-            CrosstermEvent::Key(_) => None, // Ignore Release and Repeat
+            CrosstermEvent::Key(key)
+                if matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) =>
+            {
+                Some(Event::Key(key))
+            }
+            CrosstermEvent::Key(_) => None, // Ignore Release
             CrosstermEvent::Mouse(mouse) => Some(Event::Mouse(mouse)),
             CrosstermEvent::Resize(width, height) => Some(Event::Resize(width, height)),
             CrosstermEvent::FocusLost => Some(Event::FocusLost),
             CrosstermEvent::FocusGained => Some(Event::FocusGained),
             CrosstermEvent::Paste(text) => Some(Event::Paste(text)),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key_event(kind: KeyEventKind) -> CrosstermEvent {
+        CrosstermEvent::Key(KeyEvent::new_with_kind(
+            KeyCode::Down,
+            KeyModifiers::NONE,
+            kind,
+        ))
+    }
+
+    /// Regression: held-key auto-repeat. Under the Kitty keyboard protocol
+    /// (`REPORT_EVENT_TYPES`) a held key streams `Repeat` events; they must be
+    /// delivered as `Press` — so navigation and panel resize keep firing
+    /// while a key is held.
+    #[test]
+    fn repeat_key_is_treated_as_input() {
+        let handler = EventHandler::new(Duration::from_millis(50));
+        match handler.convert_crossterm_event(key_event(KeyEventKind::Repeat)) {
+            Some(Event::Key(key)) => assert_eq!(key.code, KeyCode::Down),
+            other => panic!("Repeat should yield a key event, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn press_key_is_treated_as_input() {
+        let handler = EventHandler::new(Duration::from_millis(50));
+        match handler.convert_crossterm_event(key_event(KeyEventKind::Press)) {
+            Some(Event::Key(key)) => assert_eq!(key.code, KeyCode::Down),
+            other => panic!("Press should yield a key event, got {other:?}"),
+        }
+    }
+
+    /// `Release` carries no actionable input and must stay filtered out, so a
+    /// single key tap still produces exactly one action.
+    #[test]
+    fn release_key_is_ignored() {
+        let handler = EventHandler::new(Duration::from_millis(50));
+        assert!(
+            handler
+                .convert_crossterm_event(key_event(KeyEventKind::Release))
+                .is_none(),
+            "Release events must be discarded"
+        );
     }
 }
 


### PR DESCRIPTION
termide enables the Kitty keyboard protocol's REPORT_EVENT_TYPES, so a held key streams KeyEventKind::Repeat events. The event handler accepted only Press and discarded Release and Repeat, so held keys did nothing on Kitty-protocol terminals. Legacy terminals deliver repeats as repeated Press events, which masked the bug there.

Treat Repeat the same as Press at all three dispatch points in crates/core/src/event.rs (next, drain_non_press_keys, convert_crossterm_event); only Release is still dropped. This restores auto-repeat.

Add regression tests for the Press/Repeat/Release contract.